### PR TITLE
prepare v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,45 +16,33 @@ making use of a special
 Imagine we have a service that can divide a
 double by another double.
 
-We might model the input and output data for this
-service as follows:
+We might model this service as follows:
 ```kotlin
-data class DivisionRequest(val dividend: Double, val divisor: Double)
+interface DivisionService {
+  suspend fun divide(dividend: Double, divisor: Double): Division
 
-sealed class Division {
-  data class Success(val quotient: Double) : Division()
-  data class Error(val message: String) : Division()
+  sealed class Division {
+    data class Success(val quotient: Double) : Division()
+    data class Error(val message: String) : Division()
+  }
 }
 ```
 
 Next, we need to annotate the service verticle as follows:
 ```kotlin
-@EventBusService(
-    topic = "co.selim.sample.division",
-    consumes = DivisionRequest::class,
-    produces = Division::class,
-    propertyName = "divisionRequests",
-    functionName = "divide"
-)
+@EventBusService
+interface DivisionService
 ```
-
-**Note:**
-> * EventBus topics should follow package naming conventions.
-> * Custom types should be preferred over `String` etc.
-
----
 
 This will generate two things
-* An extension function to request divisions:
-```kotlin
-suspend fun Vertx.divide(request: DivisionRequest): Division
-````
-
-* An extension property to get the division
-requests:
-```kotlin
-val Vertx.divisionRequests: Flow<EventBusServiceRequest<DivisionRequest, Division>>
-```
+* An implementation of this service (`DivisionServiceImpl`).
+  This implementation forwards the parameters to subscribers
+  of the generated properties.
+* An extension property to get the division requests:
+  ```kotlin
+  val Vertx.divisionRequests: Flow<EventBusServiceRequest<DivisionRequest, Division>>
+  ```
+  Where `DivisionRequest` is a data class that wraps the two parameters.
 
 This service is fully implemented in the `example` module.
 

--- a/annotation/src/main/kotlin/co/selim/ebservice/annotation/EventBusService.kt
+++ b/annotation/src/main/kotlin/co/selim/ebservice/annotation/EventBusService.kt
@@ -1,13 +1,5 @@
 package co.selim.ebservice.annotation
 
-import kotlin.reflect.KClass
-
 @Retention(AnnotationRetention.SOURCE)
-@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
-annotation class EventBusService(
-  val topic: String,
-  val consumes: KClass<*>,
-  val produces: KClass<*>,
-  val propertyName: String,
-  val functionName: String
-)
+@Target(AnnotationTarget.CLASS)
+annotation class EventBusService

--- a/codegen/build.gradle
+++ b/codegen/build.gradle
@@ -11,6 +11,7 @@ dependencies {
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.0"
   implementation "io.vertx:vertx-core:4.0.2"
   implementation "com.squareup:kotlinpoet:1.7.2"
+  implementation "com.squareup:kotlinpoet-metadata:1.7.2"
   implementation project(':core')
 }
 

--- a/codegen/src/main/kotlin/co/selim/ebservice/codegen/CodeGenerator.kt
+++ b/codegen/src/main/kotlin/co/selim/ebservice/codegen/CodeGenerator.kt
@@ -4,32 +4,49 @@ import co.selim.ebservice.core.EventBusServiceRequest
 import co.selim.ebservice.core.EventBusServiceRequestImpl
 import com.squareup.kotlinpoet.*
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
 import io.vertx.core.Vertx
 import kotlinx.coroutines.flow.Flow
 
 internal fun generateFile(
-  topic: String
+  serviceName: ClassName
 ): FileSpec.Builder {
   val topicProperty = PropertySpec.builder(
     "TOPIC", String::class, KModifier.PRIVATE, KModifier.CONST
   )
-    .initializer("%S", topic)
+    .initializer("%S", "${serviceName.packageName}.${serviceName.simpleName.toLowerCase()}")
     .build()
 
-  return FileSpec.builder(topic, "ServiceExtensions")
+  return FileSpec.builder(serviceName.packageName, serviceName.simpleName + "Impl")
     .addProperty(topicProperty)
 }
 
-internal fun generateRequestsProperty(
-  requestType: ClassName,
-  responseType: ClassName,
+@KotlinPoetMetadataPreview
+internal fun generateRequestProperties(
+  serviceName: ClassName,
+  functions: Set<Function>
+): Iterable<PropertySpec> {
+  return functions.map { function ->
+    val requestType = when (function.parameters.size) {
+      0 -> Unit::class.asTypeName()
+      1 -> function.parameters.first().type
+      else -> ClassName(serviceName.packageName, function.name.capitalize() + "Parameters")
+    }
+    generateRequestsProperty(function.name, requestType, function.returnType, function.name + "Requests")
+  }
+}
+
+private fun generateRequestsProperty(
+  functionName: String,
+  requestType: TypeName,
+  responseType: TypeName,
   propertyName: String
 ): PropertySpec {
   val getter = FunSpec.getterBuilder()
     .addCode(
       """
       return eventBus()
-        .consumer<%T>(TOPIC)
+        .consumer<%T>(TOPIC + ".${functionName}")
         .%M(this)
         .%M()
         .%M { %T<%T, %T>(it) }
@@ -51,24 +68,86 @@ internal fun generateRequestsProperty(
     .build()
 }
 
-internal fun generateRequestFunction(
-  requestType: ClassName,
-  responseType: ClassName,
-  functionName: String
-): FunSpec {
-  return FunSpec.builder(functionName)
-    .addModifiers(KModifier.SUSPEND)
-    .addParameter("request", requestType)
-    .receiver(Vertx::class)
-    .returns(responseType)
+@KotlinPoetMetadataPreview
+internal fun generateServiceImpl(
+  service: Service
+): TypeSpec.Builder {
+  return TypeSpec.classBuilder(service.name.peerClass(service.name.simpleName + "Impl"))
+    .addSuperinterface(service.name)
+    .primaryConstructor(
+      FunSpec.constructorBuilder()
+        .addParameter("vertx", Vertx::class)
+        .build()
+    ).addProperty(
+      PropertySpec.builder("vertx", Vertx::class, KModifier.PRIVATE)
+        .initializer("vertx")
+        .build()
+    )
+}
+
+@KotlinPoetMetadataPreview
+internal fun generateFunctions(
+  fileSpec: FileSpec.Builder,
+  serviceSpec: TypeSpec.Builder,
+  functions: Set<Function>
+) {
+  functions.forEach { function ->
+    val container = if (function.parameters.size > 1) {
+      generateParameterContainer(function.name, function.parameters)
+    } else null
+    container?.let(fileSpec::addType)
+    serviceSpec.addFunction(generateFunction(function, container?.name))
+  }
+}
+
+@KotlinPoetMetadataPreview
+private fun generateParameterContainer(
+  functionName: String,
+  parameters: Set<Parameter>
+): TypeSpec {
+  return TypeSpec.classBuilder(functionName.capitalize() + "Parameters")
+    .addModifiers(KModifier.DATA)
+    .primaryConstructor(
+      FunSpec.constructorBuilder()
+        .addParameters(
+          parameters.map { parameter ->
+            ParameterSpec(parameter.name, parameter.type)
+          }
+        )
+        .build()
+    ).addProperties(
+      parameters.map { parameter ->
+        PropertySpec.builder(parameter.name, parameter.type)
+          .initializer(parameter.name)
+          .build()
+      }
+    )
+    .build()
+}
+
+
+@KotlinPoetMetadataPreview
+private fun generateFunction(function: Function, containerType: String?): FunSpec {
+  val message: String = containerType?.let { type ->
+    val params = function.parameters.joinToString { it.name }
+    "$type($params)"
+  } ?: function.parameters.map { it.name }.firstOrNull() ?: "Unit"
+  return FunSpec.builder(function.name)
+    .addModifiers(KModifier.OVERRIDE, KModifier.SUSPEND)
+    .addParameters(
+      function.parameters.map { parameter ->
+        ParameterSpec(parameter.name, parameter.type)
+      }
+    )
+    .returns(function.returnType)
     .addCode(
       """
-      return eventBus()
-        .request<%T>(TOPIC, request, %M)
+      return vertx.eventBus()
+        .request<%T>(TOPIC + ".${function.name}", $message, %M)
         .%M()
         .body()
     """.trimIndent(),
-      responseType,
+      function.returnType,
       MemberName("co.selim.ebservice.core", "deliveryOptions"),
       MemberName("io.vertx.kotlin.coroutines", "await")
     )

--- a/codegen/src/main/kotlin/co/selim/ebservice/codegen/ServiceProcessor.kt
+++ b/codegen/src/main/kotlin/co/selim/ebservice/codegen/ServiceProcessor.kt
@@ -2,13 +2,18 @@ package co.selim.ebservice.codegen
 
 import co.selim.ebservice.annotation.EventBusService
 import com.squareup.kotlinpoet.ClassName
-import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.TypeName
+import com.squareup.kotlinpoet.metadata.*
+import kotlinx.metadata.KmClassifier
 import javax.annotation.processing.*
 import javax.lang.model.SourceVersion
+import javax.lang.model.element.Element
 import javax.lang.model.element.TypeElement
-import javax.lang.model.type.MirroredTypeException
 import javax.lang.model.util.ElementFilter
+import javax.tools.Diagnostic
 
+@KotlinPoetMetadataPreview
 @SupportedSourceVersion(SourceVersion.RELEASE_8)
 @SupportedOptions("kapt.kotlin.generated")
 @SupportedAnnotationTypes("co.selim.ebservice.annotation.EventBusService")
@@ -18,59 +23,119 @@ class ServiceProcessor : AbstractProcessor() {
     if (elements.isEmpty()) return false
 
     val typeElements = ElementFilter.typesIn(elements)
-    val methodElements = ElementFilter.methodsIn(elements)
 
-    (typeElements + methodElements).forEach { element ->
-      element.getAnnotation(EventBusService::class.java)?.let { service ->
-        val consumedType = service.extractConsumedType()
-        val producedType = service.extractProducedType()
-
-        val sourceFile = generateServiceExtensions(
-          service.topic,
-          consumedType,
-          producedType,
-          service.propertyName,
-          service.functionName
-        )
-        sourceFile.writeTo(processingEnv.filer)
+    val services = typeElements.map { typeElement ->
+      val kmClass = typeElement.toImmutableKmClass()
+      if (!kmClass.isInterface) {
+        logError("Only interfaces are supported by ebservice", typeElement)
+        error("Only interfaces are supported by ebservice")
       }
+
+      val functions = kmClass.functions
+        .asSequence()
+        .filter { kmFunction ->
+          val classifier = kmFunction.returnType.classifier
+          classifier is KmClassifier.Class || classifier is KmClassifier.TypeAlias
+        }
+        .extractFunctions()
+        .toSet()
+
+      Service(kmClass.name.toClassName(), functions)
+    }
+
+    services.forEach { service ->
+      val fileSpecBuilder = generateFile(service.name)
+      fileSpecBuilder.addType(
+        generateServiceImpl(service)
+          .apply { generateFunctions(fileSpecBuilder, this, service.functions) }
+          .build()
+      )
+      generateRequestProperties(service.name, service.functions).forEach(fileSpecBuilder::addProperty)
+      fileSpecBuilder.build()
+        .writeTo(processingEnv.filer)
     }
 
     return true
   }
 
-  private fun EventBusService.extractConsumedType(): ClassName {
-    return extractClass { ClassName.bestGuess(consumes.java.name) }
-  }
+  private fun Sequence<ImmutableKmFunction>.extractFunctions(): Sequence<Function> {
+    return map { kmFunction ->
+      if (!kmFunction.isSuspend) {
+        logError("Function ${kmFunction.name} must be suspending")
+        error("Function ${kmFunction.name} must be suspending")
+      }
 
-  private fun EventBusService.extractProducedType(): ClassName {
-    return extractClass { ClassName.bestGuess(produces.java.name) }
-  }
+      val typeParameters = kmFunction.returnType.getTypeParameters()
+      val returnType = kmFunction.returnType.classifier
+        .toClassName()
+        .safelyParameterizedBy(typeParameters)
 
-  private fun extractClass(block: () -> ClassName): ClassName {
-    return try {
-      block()
-    } catch (e: MirroredTypeException) {
-      val typeElement = processingEnv.typeUtils.asElement(e.typeMirror) as TypeElement
-      val qualifiedName = typeElement.qualifiedName.toString()
-      ClassName.bestGuess(qualifiedName)
+      val parameters = kmFunction.valueParameters
+        .asSequence()
+        .onEach { parameter ->
+          if (parameter.varargElementType != null) {
+            logError("Vararg parameters are not supported by ebservice")
+            error("Vararg parameters are not supported by ebservice")
+          }
+        }
+        .filter { parameter ->
+          val classifier = parameter.type!!.classifier
+          classifier is KmClassifier.Class || classifier is KmClassifier.TypeAlias
+        }
+        .toFunctionParameters()
+        .toSet()
+
+      Function(kmFunction.name, returnType, parameters)
     }
+  }
+
+  private fun Sequence<ImmutableKmValueParameter>.toFunctionParameters(): Sequence<Parameter> {
+    return map { kmValueParameter ->
+      val classifier = kmValueParameter.type!!.classifier
+      val typeParametersOfParameter = kmValueParameter.type!!.getTypeParameters()
+      val typeOfParameter = classifier.toClassName().safelyParameterizedBy(typeParametersOfParameter)
+      Parameter(kmValueParameter.name, typeOfParameter)
+    }
+  }
+
+  private fun logError(msg: String, element: Element? = null) {
+    processingEnv.messager.printMessage(Diagnostic.Kind.ERROR, msg, element)
+  }
+
+  private fun ImmutableKmType.getTypeParameters(): List<TypeName> {
+    return arguments.mapNotNull { typeProjection ->
+      val params = typeProjection.type?.getTypeParameters()
+
+      when (val classifier = typeProjection.type?.classifier) {
+        is KmClassifier.Class -> classifier.toClassName().safelyParameterizedBy(params)
+        is KmClassifier.TypeParameter,
+        is KmClassifier.TypeAlias,
+        null -> null
+      }
+    }
+  }
+
+  private fun ClassName.safelyParameterizedBy(typeNames: List<TypeName>?): TypeName {
+    return if (typeNames.isNullOrEmpty()) {
+      this
+    } else {
+      this.parameterizedBy(typeNames)
+    }
+  }
+
+  private fun KmClassifier.toClassName(): ClassName {
+    return when (this) {
+      is KmClassifier.Class -> name.toClassName()
+      is KmClassifier.TypeAlias -> name.toClassName()
+      is KmClassifier.TypeParameter -> error("Type parameters are not supported")
+    }
+  }
+
+  private fun String.toClassName(): ClassName {
+    return ClassName(substringBeforeLast('/').replace('/', '.'), substringAfterLast('/'))
   }
 
   override fun getSupportedAnnotationTypes(): Set<String> {
     return setOf(EventBusService::class.java.name)
-  }
-
-  private fun generateServiceExtensions(
-    topic: String,
-    consumedType: ClassName,
-    producedType: ClassName,
-    propertyName: String,
-    functionName: String
-  ): FileSpec {
-    return generateFile(topic)
-      .addProperty(generateRequestsProperty(consumedType, producedType, propertyName))
-      .addFunction(generateRequestFunction(consumedType, producedType, functionName))
-      .build()
   }
 }

--- a/codegen/src/main/kotlin/co/selim/ebservice/codegen/model.kt
+++ b/codegen/src/main/kotlin/co/selim/ebservice/codegen/model.kt
@@ -1,0 +1,8 @@
+package co.selim.ebservice.codegen
+
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.TypeName
+
+data class Service(val name: ClassName, val functions: Set<Function>)
+data class Function(val name: String, val returnType: TypeName, val parameters: Set<Parameter>)
+data class Parameter(val name: String, val type: TypeName)

--- a/example/src/main/kotlin/co/selim/ebservice/example/Sample.kt
+++ b/example/src/main/kotlin/co/selim/ebservice/example/Sample.kt
@@ -17,11 +17,15 @@ interface MathService {
     data class Success(val quotient: Double) : Division()
     data class Error(val message: String) : Division()
   }
+
+  companion object {
+    fun create(vertx: Vertx): MathService = MathServiceImpl(vertx)
+  }
 }
 
 class SampleVerticle : CoroutineVerticle() {
   override suspend fun start() {
-    val mathService = MathServiceImpl(vertx)
+    val mathService = MathService.create(vertx)
 
     val sum = mathService.add(3.3, 4.5)
     println(sum)

--- a/example/src/main/kotlin/co/selim/ebservice/example/Sample.kt
+++ b/example/src/main/kotlin/co/selim/ebservice/example/Sample.kt
@@ -2,58 +2,63 @@ package co.selim.ebservice.example
 
 import co.selim.ebservice.annotation.EventBusService
 import co.selim.ebservice.core.initializeServiceCodec
-import co.selim.sample.division.divide
-import co.selim.sample.division.divisionRequests
 import io.vertx.core.Vertx
 import io.vertx.kotlin.coroutines.CoroutineVerticle
 import io.vertx.kotlin.coroutines.await
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
+@EventBusService
+interface MathService {
+  suspend fun add(addendA: Double, addendB: Double): Double
+  suspend fun divide(dividend: Double, divisor: Double): Division
 
-class SampleVerticle : CoroutineVerticle() {
-  override suspend fun start() {
-    when (val divisionResult = vertx.divide(DivisionRequest(5.0, 0.0))) {
-      is Division.Success -> println("Yay! $divisionResult")
-      is Division.Error -> System.err.println(divisionResult)
-    }
-
-    when (val divisionResult = vertx.divide(DivisionRequest(5.0, 2.0))) {
-      is Division.Success -> println("Yay! $divisionResult")
-      is Division.Error -> System.err.println(divisionResult)
-    }
+  sealed class Division {
+    data class Success(val quotient: Double) : Division()
+    data class Error(val message: String) : Division()
   }
 }
 
-@EventBusService(
-  topic = "co.selim.sample.division",
-  consumes = DivisionRequest::class,
-  produces = Division::class,
-  propertyName = "divisionRequests",
-  functionName = "divide"
-)
+class SampleVerticle : CoroutineVerticle() {
+  override suspend fun start() {
+    val mathService = MathServiceImpl(vertx)
+
+    val sum = mathService.add(3.3, 4.5)
+    println(sum)
+
+    when (val divisionResult = mathService.divide(5.0, 0.0)) {
+      is MathService.Division.Success -> println(divisionResult)
+      is MathService.Division.Error -> System.err.println(divisionResult)
+    }
+
+    when (val divisionResult = mathService.divide(5.0, 2.0)) {
+      is MathService.Division.Success -> println(divisionResult)
+      is MathService.Division.Error -> System.err.println(divisionResult)
+    }
+
+  }
+}
+
 class DivisionVerticle : CoroutineVerticle() {
   override suspend fun start() {
-    vertx.divisionRequests
+    vertx.divideRequests
       .onEach { (request, reply) ->
         val (dividend, divisor) = request
         reply(
           if (divisor == 0.0) {
-            Division.Error("Can't divide by zero")
+            MathService.Division.Error("Can't divide by zero")
           } else {
-            Division.Success(dividend / divisor)
+            MathService.Division.Success(dividend / divisor)
           }
         )
       }.launchIn(this)
+
+    vertx.addRequests
+      .onEach { (request, reply) ->
+        val (addendA, addendB) = request
+        reply(addendA + addendB)
+      }.launchIn(this)
   }
-}
-
-
-data class DivisionRequest(val dividend: Double, val divisor: Double)
-
-sealed class Division {
-  data class Success(val quotient: Double) : Division()
-  data class Error(val message: String) : Division()
 }
 
 suspend fun main() {


### PR DESCRIPTION
This release simplifies service generation. Rather than providing the service description full of boilerplate like so:
```kotlin
data class DivisionRequest(val dividend: Double, val divisor: Double)

sealed class DivisionResponse {
  data class Success(val quotient: Double) : DivisionResponse()
  data class Error(val message: String) : DivisionResponse()
}

@EventBusService(
    topic = "co.selim.sample.division",
    consumes = DivisionRequest::class,
    produces = DivisionResponse::class,
    propertyName = "divisionRequests",
    functionName = "divide"
)
```

You instead provide an interface like so:

```kotlin
@EventBusService
interface DivisionService {
  suspend fun divide(dividend: Double, divisor: Double): DivisonResponse

  sealed class DivisionResponse {
    data class Success(val quotient: Double) : DivisionResponse()
    data class Error(val message: String) : DivisionResponse()
  }
}
```

This let's us generate an implementation of this interface `DivisionServiceImpl` that handles the topic for us. Therefore no function name is required. The property names follow the function names. Example:
|Function|Property|
|---|---|
|divide|divideRequests|

Requests to this service can be handled via `vertx.divideRequests`. The signature remains unchanged from the previous release.