### PR TITLE
add modifier for property visibilities

### DIFF
--- a/annotation/src/main/kotlin/co/selim/ebservice/annotation/EventBusService.kt
+++ b/annotation/src/main/kotlin/co/selim/ebservice/annotation/EventBusService.kt
@@ -2,4 +2,10 @@ package co.selim.ebservice.annotation
 
 @Retention(AnnotationRetention.SOURCE)
 @Target(AnnotationTarget.CLASS)
-annotation class EventBusService
+annotation class EventBusService(
+  val propertyVisibility: Visibility = Visibility.INTERNAL
+)
+
+enum class Visibility {
+  PUBLIC, INTERNAL
+}

--- a/codegen/src/main/kotlin/co/selim/ebservice/codegen/ServiceProcessor.kt
+++ b/codegen/src/main/kotlin/co/selim/ebservice/codegen/ServiceProcessor.kt
@@ -40,7 +40,8 @@ class ServiceProcessor : AbstractProcessor() {
         .extractFunctions()
         .toSet()
 
-      Service(kmClass.name.toClassName(), functions)
+      val annotation = typeElement.getAnnotation(EventBusService::class.java)
+      Service(kmClass.name.toClassName(), functions, annotation.propertyVisibility)
     }
 
     services.forEach { service ->
@@ -50,7 +51,8 @@ class ServiceProcessor : AbstractProcessor() {
           .apply { generateFunctions(fileSpecBuilder, this, service.functions) }
           .build()
       )
-      generateRequestProperties(service.name, service.functions).forEach(fileSpecBuilder::addProperty)
+      generateRequestProperties(service.name, service.functions, service.propertyVisibility)
+        .forEach(fileSpecBuilder::addProperty)
       fileSpecBuilder.build()
         .writeTo(processingEnv.filer)
     }

--- a/codegen/src/main/kotlin/co/selim/ebservice/codegen/model.kt
+++ b/codegen/src/main/kotlin/co/selim/ebservice/codegen/model.kt
@@ -1,8 +1,9 @@
 package co.selim.ebservice.codegen
 
+import co.selim.ebservice.annotation.Visibility
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.TypeName
 
-data class Service(val name: ClassName, val functions: Set<Function>)
+data class Service(val name: ClassName, val functions: Set<Function>, val propertyVisibility: Visibility)
 data class Function(val name: String, val returnType: TypeName, val parameters: Set<Parameter>)
 data class Parameter(val name: String, val type: TypeName)


### PR DESCRIPTION
This PR makes the generated properties internal by default. This is useful for multi-module projects where you might want to hide these properties from other modules, which should only be able to _call_ the service, rather than provide it.
The properties can be made public with the newly added flag in the constructor of the annotation.

Signed-off-by: Selim Dincer <wowselim@live.de>